### PR TITLE
Chase down 404s

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-:py:mod:`ploneconf.site_sneak`
-==============================
+ploneconf.site_sneak
+====================
 
-package used for trainings
+This package is obsolete and was superseded by https://github.com/collective/ploneconf.site
 
-Obsolete; see http://training.plone.org/4/sneak.html
-Superseded by https://github.com/collective/ploneconf.site
+See https://training.plone.org/5/mastering-plone/code.html

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-ploneconf.site_sneak
-====================
+:py:mod:`ploneconf.site_sneak`
+==============================
 
 package used for trainings
 
-See http://plone-training.readthedocs.org/en/latest/sneak.html
+Obsolete; see http://training.plone.org/4/sneak.html
+Superseded by https://github.com/collective/ploneconf.site


### PR DESCRIPTION
http://plone-training.readthedocs.org/ says
> Mastering Plone moved to http://training.plone.org

The module is referenced in
https://training.plone.org/4/user_generated_content.html
as https://training.plone.org/4/sneak.html
but is (intentionally) absent in
https://training.plone.org/5/mastering-plone/index.html

This is explained in code.rst, which is not included in any TOC.